### PR TITLE
Add workaround for building docs on mac

### DIFF
--- a/.github/workflows/correctness-linux.yaml
+++ b/.github/workflows/correctness-linux.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Install Dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
+          sudo apt-get update
           git clone https://github.com/spack/spack.git
           source spack/share/spack/setup-env.sh
           spack repo add --name my_pkgs https://github.com/jrood-nrel/spack-packages.git ${{ github.workspace }}/my_pkgs

--- a/docs/sphinx/developer/documentation.rst
+++ b/docs/sphinx/developer/documentation.rst
@@ -107,17 +107,17 @@ To build the documentation:
 
        $ export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib
 
-   Alternatively, macOS users can avoid the cmake build described above and build the documentation directly with sphinx:
+   Alternatively, macOS users can avoid the CMake ``docs`` target (which runs Doxygen + Doxysphinx) and build only the Sphinx manual directly:
 
    .. code-block:: bash
 
         $ conda create -n kynema-env python=3.12
         $ conda activate kynema-env
-        $ cd $KYNEMA_FMB
-        $ pip install -r docs/requirements.txt
-        $ cd $KYNEMA_FMB/docs/sphinx
-        $ sphinx-build -M html . html/
-        $ open html/html/index.html
+         $ cd /path/to/kynema-fmb
+         $ pip install -r docs/requirements.txt
+         $ cd docs/sphinx
+         $ sphinx-build -b html . html
+         $ open html/index.html
 
    This does not generate the source code documentation and will produce a warning about a missing ``doxygen/html/index`` file.
 

--- a/docs/sphinx/developer/documentation.rst
+++ b/docs/sphinx/developer/documentation.rst
@@ -107,5 +107,19 @@ To build the documentation:
 
        $ export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib
 
+   Alternatively, macOS users can avoid the cmake build described above and build the documentation directly with sphinx:
+
+   .. code-block:: bash
+
+        $ conda create -n kynema-env python=3.12
+        $ conda activate kynema-env
+        $ cd $KYNEMA_FMB
+        $ pip install -r docs/requirements.txt
+        $ cd $KYNEMA_FMB/docs/sphinx
+        $ sphinx-build -M html . html/
+        $ open html/html/index.html
+
+   This does not generate the source code documentation and will produce a warning about a missing ``doxygen/html/index`` file.
+
 The built documentation will be available in the ``docs/sphinx/html`` directory. For other output formats,
 see the `Sphinx documentation <https://www.sphinx-doc.org/en/master/usage/builders/index.html>`_.


### PR DESCRIPTION
This PR includes documentation for how to build the docs on a Mac and closes #549 .
