### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "Kynema-FMB: A Performance-Portable Flexible-Multibody-Dynamics Solver"
+authors:
+  - family-names: "Sprague"
+    given-names: "Michael"
+    orcid: "https://orcid.org/0000-0003-0519-0379"
+  - family-names: "Slaughter"
+    given-names: "Derek"
+  - family-names: "Dement"
+    given-names: "David"
+  - family-names: "Bhuiyan"
+    given-names: "Faisal"
+    orcid: "https://orcid.org/0009-0001-1029-0908"
+  - family-names: "Kuhn"
+    given-names: "Michael"
+    orcid: "https://orcid.org/0000-0002-5506-7777"
+  - family-names: "Crozier"
+    given-names: "Paul S."
+repository-code: "https://github.com/kynema/kynema-fmb"
+license: "MIT"
+version: "0.1.0"


### PR DESCRIPTION
JOSS reviewers ask for a `CITATION.cff`, and this repository does not have one yet.

Generated from the author list in `origin/joss:joss/paper.md`: 6 author(s), with given and family names taken from each author's ORCID record rather than split from the display name, because compound surnames do not split reliably.

3 author(s) have no ORCID in the paper, so their names were split at the last word. Please correct those if I put the boundary in the wrong place.

`license` is `MIT`, read from the LICENSE file. `version` is `0.1.0`, the newest release tag. 

Verified with `cffconvert --validate`: valid against schema 1.2.0.